### PR TITLE
Incorporate switch to using pyproject.toml in CLAUDE.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ pytest tests/test_crossref.py::test_get_pdf_urls_uses_cache -v
 
 CI (`.github/workflows/main.yml`) runs `make lint` then `make test` on Linux/macOS/Windows for Python 3.12, and requires the linter job to pass first. CONTRIBUTING.md states the project targets 100% coverage on new code.
 
-There is no `setup.py` or `requirements.txt`; project metadata and dependencies live in `pyproject.toml` (`[project]`/`dependencies`, `[project.optional-dependencies]` for `examples`, `[dependency-groups]` for `dev`/`docs`/`publishing`), and the package is installed via setuptools (`[build-system]`/`[tool.setuptools...]`). Tool config (`ruff`, `mypy`, `pytest`, `coverage`, `bumpversion`) also lives in `pyproject.toml` rather than separate `pytest.ini`/`.coveragerc` files. Don't assume Poetry is in use — the Makefile still has harmless `USING_POETRY` no-op guards in `show`/`install`/`virtualenv` (they check for a `[tool.poetry]` section in `pyproject.toml`, which isn't there), but the `switch-to-poetry` target itself was removed since it referenced `requirements*.txt`/`setup.py` files that no longer exist.
+There is no `setup.py` or `requirements.txt`; project metadata and dependencies live in `pyproject.toml` (`[project]`/`dependencies`, `[project.optional-dependencies]` for `examples`, `[dependency-groups]` for `dev`/`docs`/`publishing`), and the package is installed via setuptools (`[build-system]`/`[tool.setuptools...]`). Tool config (`ruff`, `mypy`, `pytest`, `coverage`, `bumpversion`) also lives in `pyproject.toml` rather than separate `pytest.ini`/`.coveragerc` files.
 
 For testing the syntax of CITATION.cff (requires installation of `cffconvert` with `pipx`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 make virtualenv          # create .venv and install project + test deps
 source .venv/bin/activate
-make install              # pip install -e .[test] (rerun after changing requirements*.txt)
+make install              # pip install -e .[examples] --group dev --group docs --group publishing (rerun after changing pyproject.toml deps)
 
 make fmt                  # format doi_downloader/ with ruff
 make lint                 # ruff check doi_downloader/
@@ -38,7 +38,7 @@ pytest tests/test_crossref.py::test_get_pdf_urls_uses_cache -v
 
 CI (`.github/workflows/main.yml`) runs `make lint` then `make test` on Linux/macOS/Windows for Python 3.12, and requires the linter job to pass first. CONTRIBUTING.md states the project targets 100% coverage on new code.
 
-There is no `pyproject.toml`; dependencies are pinned in `requirements.txt` (runtime) and installed via `setup.py`'s `install_requires`. `make switch-to-poetry` exists but switches the whole project to Poetry and is not the current setup — don't assume Poetry is in use.
+There is no `setup.py` or `requirements.txt`; project metadata and dependencies live in `pyproject.toml` (`[project]`/`dependencies`, `[project.optional-dependencies]` for `examples`, `[dependency-groups]` for `dev`/`docs`/`publishing`), and the package is installed via setuptools (`[build-system]`/`[tool.setuptools...]`). Tool config (`ruff`, `mypy`, `pytest`, `coverage`, `bumpversion`) also lives in `pyproject.toml` rather than separate `pytest.ini`/`.coveragerc` files. Don't assume Poetry is in use — the Makefile still has harmless `USING_POETRY` no-op guards in `show`/`install`/`virtualenv` (they check for a `[tool.poetry]` section in `pyproject.toml`, which isn't there), but the `switch-to-poetry` target itself was removed since it referenced `requirements*.txt`/`setup.py` files that no longer exist.
 
 For testing the syntax of CITATION.cff (requires installation of `cffconvert` with `pipx`):
 
@@ -62,7 +62,7 @@ Plugins that need credentials read them from a `.env` file in the repo root (loa
 - `SERPAPI_KEY` — required by the Google Scholar plugin
 - `CORE_API_KEY` — required by the CORE plugin
 
-Tests load `.env` via `pytest.ini`'s `env_files` (pytest-dotenv), and `tests/conftest.py` runs every test inside a temp cwd, so tests never touch the real `database.db` or `downloads/` in the repo root.
+Tests load `.env` via `pyproject.toml`'s `[tool.pytest.ini_options]` `env_files` setting (pytest-dotenv), and `tests/conftest.py` runs every test inside a temp cwd, so tests never touch the real `database.db` or `downloads/` in the repo root.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ pytest tests/test_crossref.py::test_get_pdf_urls_uses_cache -v
 
 CI (`.github/workflows/main.yml`) runs `make lint` then `make test` on Linux/macOS/Windows for Python 3.12, and requires the linter job to pass first. CONTRIBUTING.md states the project targets 100% coverage on new code.
 
+This repo also has a `.pre-commit-config.yaml` (not currently wired into CI, so it's a local-only safety net unless `pre-commit install` has been run): it blocks committing leftover Copier `.rej` files, validates JSON/TOML/YAML syntax, fixes end-of-file/line-ending/trailing-whitespace issues, blocks commits directly to certain branches (`no-commit-to-branch`), checks for merge-conflict markers, validates `CITATION.cff` (`cffconvert`), formats/lints YAML (`yamlfmt`/`yamllint`), and runs `ruff check --fix` + `ruff format`. Its `ruff-pre-commit` hook is pinned via `rev:` independently of `pyproject.toml`'s `dev` group `ruff` entry — the two can drift out of sync (as they currently do here), so `pre-commit run` locally isn't guaranteed to catch everything `make lint`/CI will flag, or vice versa; when bumping one, bump the other to match.
+
 There is no `setup.py` or `requirements.txt`; project metadata and dependencies live in `pyproject.toml` (`[project]`/`dependencies`, `[project.optional-dependencies]` for `examples`, `[dependency-groups]` for `dev`/`docs`/`publishing`), and the package is installed via setuptools (`[build-system]`/`[tool.setuptools...]`). Tool config (`ruff`, `mypy`, `pytest`, `coverage`, `bumpversion`) also lives in `pyproject.toml` rather than separate `pytest.ini`/`.coveragerc` files.
 
 For testing the syntax of CITATION.cff (requires installation of `cffconvert` with `pipx`):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,8 @@ Usage: make <target>
 
 Targets:
 help:             ## Show the help.
+run:              ## Run the application.
+show:             ## Show the current environment.
 install:          ## Install the project in dev mode.
 fmt:              ## Format code using black & isort.
 lint:             ## Run pep8, black, mypy linters.
@@ -87,8 +89,8 @@ clean:            ## Clean unused files.
 virtualenv:       ## Create a virtual environment.
 release:          ## Create a new tag for release.
 docs:             ## Build the documentation.
-switch-to-poetry: ## Switch to poetry package manager.
-init:             ## Initialize the project based on an application template.
+docs-serve: docs  ## Serve the documentation locally.
+docs-deploy: docs ## Deploy the documentation to gh-pages branch.
 ```
 
 ## Making a new release

--- a/Makefile
+++ b/Makefile
@@ -105,25 +105,6 @@ docs-deploy: docs ## Deploy the documentation to gh-pages branch.
 	@$(ENV_PREFIX)mkdocs gh-deploy
 
 
-.PHONY: switch-to-poetry
-switch-to-poetry: ## Switch to poetry package manager.
-	@echo "Switching to poetry ..."
-	@if ! poetry --version > /dev/null; then echo 'poetry is required, install from https://python-poetry.org/'; exit 1; fi
-	@rm -rf .venv
-	@poetry init --no-interaction --name=a_flask_test --author=rochacbruno
-	@echo "" >> pyproject.toml
-	@echo "[tool.poetry.scripts]" >> pyproject.toml
-	@echo "doi_downloader = 'doi_downloader.__main__:main'" >> pyproject.toml
-	@cat requirements.txt | while read in; do poetry add --no-interaction "$${in}"; done
-	@cat requirements-test.txt | while read in; do poetry add --no-interaction "$${in}" --dev; done
-	@poetry install --no-interaction
-	@mkdir -p .github/backup
-	@mv requirements* .github/backup
-	@mv setup.py .github/backup
-	@echo "You have switched to https://python-poetry.org/ package manager."
-	@echo "Please run 'poetry shell' or 'poetry run doi_downloader'"
-
-
 # This project has been generated from rochacbruno/python-project-template
 # __author__ = 'rochacbruno'
 # __repo__ = https://github.com/rochacbruno/python-project-template

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .ONESHELL:
 ENV_PREFIX=$(shell python -c "if __import__('pathlib').Path('.venv/bin/pip').exists(): print('.venv/bin/')")
-USING_POETRY=$(shell grep "tool.poetry" pyproject.toml && echo "yes")
 
 .PHONY: help
 help:             ## Show the help.
@@ -17,14 +16,12 @@ run:              ## Run the application.
 .PHONY: show
 show:             ## Show the current environment.
 	@echo "Current environment:"
-	@if [ "$(USING_POETRY)" ]; then poetry env info && exit; fi
 	@echo "Running using $(ENV_PREFIX)"
 	@$(ENV_PREFIX)python -V
 	@$(ENV_PREFIX)python -m site
 
 .PHONY: install
 install:          ## Install the project in dev mode.
-	@if [ "$(USING_POETRY)" ]; then poetry install && exit; fi
 	@echo "Don't forget to run 'make virtualenv' if you got errors."
 	$(ENV_PREFIX)pip install -e .[examples] --group dev --group docs --group publishing
 
@@ -65,7 +62,6 @@ clean:            ## Clean unused files.
 
 .PHONY: virtualenv
 virtualenv:       ## Create a virtual environment.
-	@if [ "$(USING_POETRY)" ]; then poetry install && exit; fi
 	@echo "creating virtualenv ..."
 	@rm -rf .venv
 	@python -m venv .venv


### PR DESCRIPTION
### Summary :memo:

After switching this repository to using `pyproject.toml` from `setup.py` (PR #62 ), the file CLAUDE.md required updating. Changing this file led to some other required updates.

### Details

1. Removed references to `setup.py`, `requirements*txt` and `pytest.ini` from `CLAUDE.md`. Added references to `pyproject.toml`
2. Removed the `switch-to-poetry` target from `Makefile`, it referenced `setup.py` and the whole  target had become obsolete
3. Removed `switch-to-poetry` from the `Makefile` section in `CONTRIBUTING.md`. Added missing `Makefile` targets
4. Removed `setup.py`-related lines from `.github/workflows/release.yml` and replaced them with `pyproject.toml` style lines

### Checks

- [x] Installed package with `make install` and tested it with `make test`